### PR TITLE
Atualização para correção: Failure to launch NiFi

### DIFF
--- a/docker-compose-nifi.yml
+++ b/docker-compose-nifi.yml
@@ -21,6 +21,7 @@ services:
       - NIFI_CLUSTER_NODE_PROTOCOL_PORT=8082
       - NIFI_ZK_CONNECT_STRING=zookeeper-nifi:2181
       - NIFI_ELECTION_MAX_WAIT=1 min
+      - NIFI_SENSITIVE_PROPS_KEY=123456789012
     networks:
       - pipeline-data-net
     volumes:


### PR DESCRIPTION
ERROR [main] org.apache.nifi.NiFi Failure to launch NiFi java.lang.IllegalArgumentException: There was an issue decrypting protected properties
	at org.apache.nifi.NiFi.initializeProperties(NiFi.java:375)
	at org.apache.nifi.NiFi.convertArgumentsToValidatedNiFiProperties(NiFi.java:343)
	at org.apache.nifi.NiFi.convertArgumentsToValidatedNiFiProperties(NiFi.java:339)
	at org.apache.nifi.NiFi.main(NiFi.java:331)

Caused by: org.apache.nifi.properties.SensitivePropertyProtectionException: Sensitive Properties Key [nifi.sensitive.props.key] not found: See Admin Guide section [Updating the Sensitive Properties Key]

	at org.apache.nifi.properties.NiFiPropertiesLoader.getDefaultProperties(NiFiPropertiesLoader.java:233)
	at org.apache.nifi.properties.NiFiPropertiesLoader.get(NiFiPropertiesLoader.java:218)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.nifi.NiFi.initializeProperties(NiFi.java:370)